### PR TITLE
Upgrade Zephyr from v3.7.0 to v4.1.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -13,6 +13,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v3.7.0
-      import: 
+      revision: v4.1.0
+      import:
         path-prefix: deps
+


### PR DESCRIPTION
I have tested both HelloWorld.lf and Blinky.lf on the Raspberry Pi 4. There are no compilation errors, and both programs run correctly.

@hokeun 







